### PR TITLE
handle problem when old password not exists in password archivable feature

### DIFF
--- a/lib/devise_security_extension/models/password_archivable.rb
+++ b/lib/devise_security_extension/models/password_archivable.rb
@@ -49,13 +49,17 @@ module Devise
       # archive the last password before save and delete all to old passwords from archive
       def archive_password
         if self.encrypted_password_changed?
-          if self.class.password_archiving_count.to_i > 0
+          if self.class.password_archiving_count.to_i > 0 && !old_password_exists?
             self.old_passwords.create! old_password_params
             self.old_passwords.order(:id).reverse_order.offset(self.class.password_archiving_count).destroy_all
           else
             self.old_passwords.destroy_all
           end
         end
+      end
+      
+      def old_password_exists?
+        old_password_params.encrypted_password.present?
       end
       
       def old_password_params


### PR DESCRIPTION
to fix the problem of password archivable feature. When create user from admin page no need password. Hence, when user try to add password, it raise error because the old password is nil
